### PR TITLE
Add row calculation to the UI

### DIFF
--- a/apps/gauge-calculator/test/app_test.rb
+++ b/apps/gauge-calculator/test/app_test.rb
@@ -13,8 +13,10 @@ class GaugeCalculatorAppTest < Minitest::Test
     assert_equal "38", html.at_css("input#targetWidth")["value"]
     assert_equal "optional", html.at_css("input#repeat")["placeholder"]
     assert_equal "0", html.at_css("input#offset")["value"]
+    assert_equal "10", html.at_css("input#targetHeight")["value"]
     assert_includes last_response.body, "calculate my gauge!"
     assert_includes last_response.body, "calculate stitches"
+    assert_includes last_response.body, "calculate rows"
   end
 
   def test_get_root_includes_javascript_hooks_for_the_gauge_endpoints
@@ -23,9 +25,11 @@ class GaugeCalculatorAppTest < Minitest::Test
     assert last_response.ok?
     assert_includes last_response.body, 'fetch("/api/gauge"'
     assert_includes last_response.body, 'fetch("/api/gauge/stitches"'
+    assert_includes last_response.body, 'fetch("/api/gauge/rows"'
     assert_includes last_response.body, 'document.getElementById("spi").innerText = data.spi'
     assert_includes last_response.body, "let base = data.stitches"
     assert_includes last_response.body, "if (repeat)"
     assert_includes last_response.body, '`${base} -> ${adjusted} (adjusted)`'
+    assert_includes last_response.body, 'document.getElementById("rowResult").innerText = data.rows'
   end
 end

--- a/apps/gauge-calculator/views/gauge.erb
+++ b/apps/gauge-calculator/views/gauge.erb
@@ -106,6 +106,29 @@
     </div>
   </div>
 
+  <div class="mt-6 space-y-3">
+    <div>
+      <label for="targetHeight" class="block text-sm font-semibold text-gray-700">
+        desired height of your project (inches)
+      </label>
+      <p class="text-xs text-gray-400 mb-1">
+        how tall do you want the finished piece?
+      </p>
+      <input id="targetHeight" type="number" value="10"
+        class="w-full p-3 rounded-xl border border-pink-200 focus:outline-none focus:ring-2 focus:ring-pink-300">
+    </div>
+
+    <button onclick="calculateRows()"
+      class="w-full bg-pink-500 hover:bg-pink-600 text-white font-medium p-3 rounded-xl transition">
+      calculate rows 🧶
+    </button>
+
+    <div class="bg-pink-50 rounded-xl p-4 text-center">
+      <p class="text-xs text-gray-500">you need</p>
+      <p id="rowResult" class="text-lg font-bold text-pink-600"></p>
+    </div>
+  </div>
+
   <div class="mt-6 space-y-5">
     <div class="my-6 border-t border-dashed border-pink-200"></div>
 
@@ -204,5 +227,26 @@
       repeat
         ? `${base} -> ${adjusted} (adjusted)`
         : `${base}`
+  }
+
+  async function calculateRows() {
+    const stitches = document.getElementById("stitches").value
+    const rows = document.getElementById("rows").value
+    const width = document.getElementById("width").value
+    const targetHeight = document.getElementById("targetHeight").value
+
+    const res = await fetch("/api/gauge/rows", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        stitches,
+        rows,
+        width,
+        target_height: targetHeight
+      })
+    })
+
+    const data = await res.json()
+    document.getElementById("rowResult").innerText = data.rows
   }
 </script>


### PR DESCRIPTION
## Summary
- Adds a "desired height" input and "calculate rows" button to the frontend
- Wires up the existing `/api/gauge/rows` endpoint via `calculateRows()` JS function
- Updates app tests to verify the new UI elements and JS hooks

## Test plan
- [x] `bundle exec rake test` passes (9 tests, 67 assertions)
- [ ] Manual: enter swatch measurements, click "calculate rows", verify correct row count appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)