### PR TITLE
Add unit toggle for inches/centimeters

### DIFF
--- a/apps/gauge-calculator/test/app_test.rb
+++ b/apps/gauge-calculator/test/app_test.rb
@@ -7,6 +7,10 @@ class GaugeCalculatorAppTest < Minitest::Test
     assert last_response.ok?
     assert_equal "Gauge Calculator ✿", html.at("title").text
     assert_match(/gauge calculator/i, html.at("h1").text)
+    unit_select = html.at_css("select#unit")
+    assert unit_select, "expected a unit select element"
+    options = unit_select.css("option").map { |o| o["value"] }
+    assert_equal %w[inches centimeters], options
     assert_equal "18", html.at_css("input#stitches")["value"]
     assert_equal "24", html.at_css("input#rows")["value"]
     assert_equal "4", html.at_css("input#width")["value"]
@@ -31,5 +35,7 @@ class GaugeCalculatorAppTest < Minitest::Test
     assert_includes last_response.body, "if (repeat)"
     assert_includes last_response.body, '`${base} -> ${adjusted} (adjusted)`'
     assert_includes last_response.body, 'document.getElementById("rowResult").innerText = data.rows'
+    assert_includes last_response.body, "function getUnit()"
+    assert_includes last_response.body, "function updateUnitLabels()"
   end
 end

--- a/apps/gauge-calculator/views/gauge.erb
+++ b/apps/gauge-calculator/views/gauge.erb
@@ -8,6 +8,15 @@
     <span class="text-xs">pro tip: block your swatch before measuring for best results</span>
   </p>
 
+  <div class="mb-4">
+    <label for="unit" class="block text-sm font-semibold text-gray-700 mb-1">units</label>
+    <select id="unit" onchange="updateUnitLabels()"
+      class="w-full p-3 rounded-xl border border-pink-200 focus:outline-none focus:ring-2 focus:ring-pink-300 bg-white">
+      <option value="inches" selected>inches</option>
+      <option value="centimeters">centimeters</option>
+    </select>
+  </div>
+
   <div class="space-y-5">
     <p class="text-sm text-gray-500 mb-2">your swatch ✿</p>
 
@@ -35,7 +44,7 @@
 
     <div>
       <label for="width" class="block text-sm font-semibold text-gray-700">
-        width you measured (inches)
+        width you measured (<span class="unitLabel">inches</span>)
       </label>
       <p class="text-xs text-gray-400 mb-1">
         measure your swatch area (ignore the edges!)
@@ -60,7 +69,7 @@
       <p id="spi" class="text-lg font-bold text-pink-600"></p>
 
       <div class="tooltip-text">
-        stitches per inch - how many stitches fit in one inch of your fabric
+        stitches per <span class="unitLabelSingular">inch</span> - how many stitches fit in one <span class="unitLabelSingular">inch</span> of your fabric
       </div>
     </div>
 
@@ -73,7 +82,7 @@
       <p id="rpi" class="text-lg font-bold text-blue-600"></p>
 
       <div class="tooltip-text">
-        rows per inch - how many rows fit in one inch of your fabric
+        rows per <span class="unitLabelSingular">inch</span> - how many rows fit in one <span class="unitLabelSingular">inch</span> of your fabric
       </div>
     </div>
   </div>
@@ -85,7 +94,7 @@
     <div class="mt-6 space-y-5">
       <div>
         <label for="targetWidth" class="block text-sm font-semibold text-gray-700">
-          desired width of your project (inches)
+          desired width of your project (<span class="unitLabel">inches</span>)
         </label>
         <p class="text-xs text-gray-400 mb-1">
           how wide do you want the finished piece?
@@ -109,7 +118,7 @@
   <div class="mt-6 space-y-3">
     <div>
       <label for="targetHeight" class="block text-sm font-semibold text-gray-700">
-        desired height of your project (inches)
+        desired height of your project (<span class="unitLabel">inches</span>)
       </label>
       <p class="text-xs text-gray-400 mb-1">
         how tall do you want the finished piece?
@@ -174,15 +183,28 @@
 </div>
 
 <script>
+  function getUnit() {
+    return document.getElementById("unit").value
+  }
+
+  function updateUnitLabels() {
+    const unit = getUnit()
+    const singular = unit === "inches" ? "inch" : "centimeter"
+
+    document.querySelectorAll(".unitLabel").forEach(el => el.innerText = unit)
+    document.querySelectorAll(".unitLabelSingular").forEach(el => el.innerText = singular)
+  }
+
   async function calculateGauge() {
     const stitches = document.getElementById("stitches").value
     const rows = document.getElementById("rows").value
     const width = document.getElementById("width").value
+    const unit = getUnit()
 
     const res = await fetch("/api/gauge", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ stitches, rows, width })
+      body: JSON.stringify({ stitches, rows, width, unit })
     })
 
     const data = await res.json()
@@ -196,6 +218,7 @@
     const rows = document.getElementById("rows").value
     const width = document.getElementById("width").value
     const targetWidth = document.getElementById("targetWidth").value
+    const unit = getUnit()
 
     const repeat = document.getElementById("repeat").value
     const offset = document.getElementById("offset").value
@@ -207,7 +230,8 @@
         stitches,
         rows,
         width,
-        target_width: targetWidth
+        target_width: targetWidth,
+        unit
       })
     })
 
@@ -234,6 +258,7 @@
     const rows = document.getElementById("rows").value
     const width = document.getElementById("width").value
     const targetHeight = document.getElementById("targetHeight").value
+    const unit = getUnit()
 
     const res = await fetch("/api/gauge/rows", {
       method: "POST",
@@ -242,7 +267,8 @@
         stitches,
         rows,
         width,
-        target_height: targetHeight
+        target_height: targetHeight,
+        unit
       })
     })
 


### PR DESCRIPTION
## Summary
- Adds a unit selector dropdown (inches / centimeters) at the top of the form
- All measurement labels update dynamically when the unit changes
- All API calls now pass the selected unit
- Tooltip descriptions use dynamic singular unit names

**Stacked on:** #4

## Test plan
- [x] `bundle exec rake test` passes (9 tests, 73 assertions)
- [ ] Manual: toggle to centimeters, verify labels update, verify API calls use cm

🤖 Generated with [Claude Code](https://claude.com/claude-code)