### PR TITLE
Move pattern repeat logic server-side

### DIFF
--- a/apps/gauge-calculator/app.rb
+++ b/apps/gauge-calculator/app.rb
@@ -33,9 +33,13 @@ class GaugeCalculatorApp < Sinatra::Base
     content_type :json
 
     gauge = build_gauge
-    stitches = gauge.required_stitches(length_param(:target_width))
+    base = gauge.required_stitches(length_param(:target_width)).value
+    adjusted = adjust_for_repeat(base)
 
-    {stitches: stitches.value}.to_json
+    result = {stitches: adjusted}
+    result[:base_stitches] = base if adjusted != base
+
+    result.to_json
   end
 
   post "/api/gauge/rows" do
@@ -72,5 +76,13 @@ class GaugeCalculatorApp < Sinatra::Base
     unit = request_params["unit"] || "inches"
 
     value.public_send(unit)
+  end
+
+  def adjust_for_repeat(base)
+    repeat = request_params["repeat"]&.to_i
+    return base unless repeat && repeat > 0
+
+    offset = (request_params["offset"] || 0).to_i
+    ((base - offset).to_f / repeat).ceil * repeat + offset
   end
 end

--- a/apps/gauge-calculator/test/api_test.rb
+++ b/apps/gauge-calculator/test/api_test.rb
@@ -56,6 +56,51 @@ class GaugeCalculatorApiTest < Minitest::Test
     assert_equal({"stitches" => 50}, json_response)
   end
 
+  def test_post_api_gauge_stitches_adjusts_for_pattern_repeat
+    fake_gauge = Object.new
+    fake_stitches = Struct.new(:value).new(191)
+
+    fake_gauge.define_singleton_method(:required_stitches) { |_| fake_stitches }
+
+    stub_class_method(FiberGauge::Gauge, :new, ->(**) { fake_gauge }) do
+      request_post "/api/gauge/stitches",
+        JSON.generate({
+          stitches: 20,
+          rows: 28,
+          width: 4,
+          target_width: 38,
+          repeat: 4,
+          offset: 2
+        }),
+        {"CONTENT_TYPE" => "application/json"}
+    end
+
+    assert last_response.ok?
+    assert_equal 194, json_response["stitches"]
+    assert_equal 191, json_response["base_stitches"]
+  end
+
+  def test_post_api_gauge_stitches_omits_base_when_no_repeat
+    fake_gauge = Object.new
+    fake_stitches = Struct.new(:value).new(190)
+
+    fake_gauge.define_singleton_method(:required_stitches) { |_| fake_stitches }
+
+    stub_class_method(FiberGauge::Gauge, :new, ->(**) { fake_gauge }) do
+      request_post "/api/gauge/stitches",
+        JSON.generate({
+          stitches: 20,
+          rows: 28,
+          width: 4,
+          target_width: 38
+        }),
+        {"CONTENT_TYPE" => "application/json"}
+    end
+
+    assert last_response.ok?
+    assert_equal({"stitches" => 190}, json_response)
+  end
+
   def test_post_api_gauge_rows_returns_required_rows_in_default_inches
     test_case = self
     fake_gauge = Object.new

--- a/apps/gauge-calculator/test/app_test.rb
+++ b/apps/gauge-calculator/test/app_test.rb
@@ -31,9 +31,8 @@ class GaugeCalculatorAppTest < Minitest::Test
     assert_includes last_response.body, 'fetch("/api/gauge/stitches"'
     assert_includes last_response.body, 'fetch("/api/gauge/rows"'
     assert_includes last_response.body, 'document.getElementById("spi").innerText = data.spi'
-    assert_includes last_response.body, "let base = data.stitches"
-    assert_includes last_response.body, "if (repeat)"
-    assert_includes last_response.body, '`${base} -> ${adjusted} (adjusted)`'
+    assert_includes last_response.body, "data.base_stitches"
+    assert_includes last_response.body, '`${data.base_stitches} -> ${data.stitches} (adjusted)`'
     assert_includes last_response.body, 'document.getElementById("rowResult").innerText = data.rows'
     assert_includes last_response.body, "function getUnit()"
     assert_includes last_response.body, "function updateUnitLabels()"

--- a/apps/gauge-calculator/views/gauge.erb
+++ b/apps/gauge-calculator/views/gauge.erb
@@ -223,34 +223,24 @@
     const repeat = document.getElementById("repeat").value
     const offset = document.getElementById("offset").value
 
+    const payload = { stitches, rows, width, target_width: targetWidth, unit }
+    if (repeat) {
+      payload.repeat = parseInt(repeat)
+      payload.offset = parseInt(offset || 0)
+    }
+
     const res = await fetch("/api/gauge/stitches", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        stitches,
-        rows,
-        width,
-        target_width: targetWidth,
-        unit
-      })
+      body: JSON.stringify(payload)
     })
 
     const data = await res.json()
 
-    let base = data.stitches
-    let adjusted = base
-
-    if (repeat) {
-      const r = parseInt(repeat)
-      const o = parseInt(offset || 0)
-
-      adjusted = Math.ceil((base - o) / r) * r + o
-    }
-
     document.getElementById("stitchResult").innerText =
-      repeat
-        ? `${base} -> ${adjusted} (adjusted)`
-        : `${base}`
+      data.base_stitches
+        ? `${data.base_stitches} -> ${data.stitches} (adjusted)`
+        : `${data.stitches}`
   }
 
   async function calculateRows() {


### PR DESCRIPTION
## Summary
- Moves repeat/offset stitch adjustment from client-side JS to the `/api/gauge/stitches` endpoint
- API now accepts optional `repeat` and `offset` params
- Returns `base_stitches` alongside `stitches` when adjustment is applied
- Client JS simplified to display server response directly

**Stacked on:** #5

## Test plan
- [x] `bundle exec rake test` passes (11 tests, 76 assertions)
- [ ] Manual: set a pattern repeat, verify adjusted count matches server response

🤖 Generated with [Claude Code](https://claude.com/claude-code)