### PR TITLE
Add validation and error handling

### DIFF
--- a/apps/gauge-calculator/app.rb
+++ b/apps/gauge-calculator/app.rb
@@ -20,6 +20,8 @@ class GaugeCalculatorApp < Sinatra::Base
 
   post "/api/gauge" do
     content_type :json
+    validate_params!("stitches", "rows", "width")
+    validate_positive!("stitches", "rows", "width")
 
     gauge = build_gauge
 
@@ -31,6 +33,8 @@ class GaugeCalculatorApp < Sinatra::Base
 
   post "/api/gauge/stitches" do
     content_type :json
+    validate_params!("stitches", "rows", "width", "target_width")
+    validate_positive!("stitches", "rows", "width", "target_width")
 
     gauge = build_gauge
     base = gauge.required_stitches(length_param(:target_width)).value
@@ -44,6 +48,8 @@ class GaugeCalculatorApp < Sinatra::Base
 
   post "/api/gauge/rows" do
     content_type :json
+    validate_params!("stitches", "rows", "width", "target_height")
+    validate_positive!("stitches", "rows", "width", "target_height")
 
     gauge = build_gauge
     rows = gauge.required_rows(length_param(:target_height))
@@ -51,7 +57,26 @@ class GaugeCalculatorApp < Sinatra::Base
     {rows: rows.value}.to_json
   end
 
+  error 422 do
+    content_type :json
+    response.body
+  end
+
   private
+
+  def validate_params!(*keys)
+    missing = keys.select { |k| request_params[k].nil? }
+    unless missing.empty?
+      halt 422, {error: "Missing required parameters: #{missing.join(", ")}"}.to_json
+    end
+  end
+
+  def validate_positive!(*keys)
+    invalid = keys.select { |k| request_params[k].to_f <= 0 }
+    unless invalid.empty?
+      halt 422, {error: "Parameters must be positive: #{invalid.join(", ")}"}.to_json
+    end
+  end
 
   def request_params
     @request_params ||= begin

--- a/apps/gauge-calculator/test/api_test.rb
+++ b/apps/gauge-calculator/test/api_test.rb
@@ -155,4 +155,41 @@ class GaugeCalculatorApiTest < Minitest::Test
     assert last_response.ok?
     assert_equal({"rows" => 70}, json_response)
   end
+
+  def test_post_api_gauge_returns_422_when_missing_required_params
+    request_post "/api/gauge",
+      JSON.generate({stitches: 20}),
+      {"CONTENT_TYPE" => "application/json"}
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "rows"
+    assert_includes json_response["error"], "width"
+  end
+
+  def test_post_api_gauge_returns_422_when_params_are_zero
+    request_post "/api/gauge",
+      JSON.generate({stitches: 0, rows: 28, width: 4}),
+      {"CONTENT_TYPE" => "application/json"}
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "stitches"
+  end
+
+  def test_post_api_gauge_stitches_returns_422_when_missing_target_width
+    request_post "/api/gauge/stitches",
+      JSON.generate({stitches: 20, rows: 28, width: 4}),
+      {"CONTENT_TYPE" => "application/json"}
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "target_width"
+  end
+
+  def test_post_api_gauge_rows_returns_422_when_missing_target_height
+    request_post "/api/gauge/rows",
+      JSON.generate({stitches: 20, rows: 28, width: 4}),
+      {"CONTENT_TYPE" => "application/json"}
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "target_height"
+  end
 end

--- a/apps/gauge-calculator/test/app_test.rb
+++ b/apps/gauge-calculator/test/app_test.rb
@@ -27,14 +27,17 @@ class GaugeCalculatorAppTest < Minitest::Test
     request_get "/"
 
     assert last_response.ok?
-    assert_includes last_response.body, 'fetch("/api/gauge"'
-    assert_includes last_response.body, 'fetch("/api/gauge/stitches"'
-    assert_includes last_response.body, 'fetch("/api/gauge/rows"'
+    assert_includes last_response.body, 'apiPost("/api/gauge"'
+    assert_includes last_response.body, 'apiPost("/api/gauge/stitches"'
+    assert_includes last_response.body, 'apiPost("/api/gauge/rows"'
     assert_includes last_response.body, 'document.getElementById("spi").innerText = data.spi'
     assert_includes last_response.body, "data.base_stitches"
     assert_includes last_response.body, '`${data.base_stitches} -> ${data.stitches} (adjusted)`'
     assert_includes last_response.body, 'document.getElementById("rowResult").innerText = data.rows'
     assert_includes last_response.body, "function getUnit()"
     assert_includes last_response.body, "function updateUnitLabels()"
+    assert_includes last_response.body, "function showError("
+    assert_includes last_response.body, "function apiPost("
+    assert html.at_css("#errorBanner"), "expected an error banner element"
   end
 end

--- a/apps/gauge-calculator/views/gauge.erb
+++ b/apps/gauge-calculator/views/gauge.erb
@@ -8,6 +8,8 @@
     <span class="text-xs">pro tip: block your swatch before measuring for best results</span>
   </p>
 
+  <div id="errorBanner" class="hidden bg-red-50 border border-red-200 text-red-600 text-sm rounded-xl p-3 mb-4"></div>
+
   <div class="mb-4">
     <label for="unit" class="block text-sm font-semibold text-gray-700 mb-1">units</label>
     <select id="unit" onchange="updateUnitLabels()"
@@ -183,6 +185,32 @@
 </div>
 
 <script>
+  function showError(message) {
+    const banner = document.getElementById("errorBanner")
+    banner.innerText = message
+    banner.classList.remove("hidden")
+  }
+
+  function clearError() {
+    const banner = document.getElementById("errorBanner")
+    banner.classList.add("hidden")
+  }
+
+  async function apiPost(url, body) {
+    clearError()
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      showError(data.error || "Something went wrong")
+      return null
+    }
+    return data
+  }
+
   function getUnit() {
     return document.getElementById("unit").value
   }
@@ -201,13 +229,8 @@
     const width = document.getElementById("width").value
     const unit = getUnit()
 
-    const res = await fetch("/api/gauge", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ stitches, rows, width, unit })
-    })
-
-    const data = await res.json()
+    const data = await apiPost("/api/gauge", { stitches, rows, width, unit })
+    if (!data) return
 
     document.getElementById("spi").innerText = data.spi
     document.getElementById("rpi").innerText = data.rpi
@@ -229,13 +252,8 @@
       payload.offset = parseInt(offset || 0)
     }
 
-    const res = await fetch("/api/gauge/stitches", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload)
-    })
-
-    const data = await res.json()
+    const data = await apiPost("/api/gauge/stitches", payload)
+    if (!data) return
 
     document.getElementById("stitchResult").innerText =
       data.base_stitches
@@ -250,19 +268,11 @@
     const targetHeight = document.getElementById("targetHeight").value
     const unit = getUnit()
 
-    const res = await fetch("/api/gauge/rows", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        stitches,
-        rows,
-        width,
-        target_height: targetHeight,
-        unit
-      })
+    const data = await apiPost("/api/gauge/rows", {
+      stitches, rows, width, target_height: targetHeight, unit
     })
+    if (!data) return
 
-    const data = await res.json()
     document.getElementById("rowResult").innerText = data.rows
   }
 </script>


### PR DESCRIPTION
## Summary
- Adds server-side validation for required params and positive values on all API endpoints
- Returns 422 with descriptive JSON error messages
- Adds client-side error banner that shows API errors and auto-clears on next request
- Extracts shared `apiPost()` JS helper for consistent error handling

**Stacked on:** #6

## Test plan
- [x] `bundle exec rake test` passes (15 tests, 95 assertions)
- [ ] Manual: submit with empty/zero fields, verify error banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)