### PR TITLE
Add required_rows method to FiberGauge::Gauge

### DIFF
--- a/gems/fiber_gauge/Gemfile
+++ b/gems/fiber_gauge/Gemfile
@@ -8,3 +8,6 @@ gemspec
 group :test do
   gem "simplecov", require: false
 end
+
+gem "rake", "~> 13.3", group: :test
+gem "simplecov-json", "~> 0.2.3", group: :test

--- a/gems/fiber_gauge/lib/fiber_gauge/gauge.rb
+++ b/gems/fiber_gauge/lib/fiber_gauge/gauge.rb
@@ -29,5 +29,12 @@ module FiberGauge
 
       count.stitches
     end
+
+    def required_rows(length)
+      inches = length.to(:inches).value
+      count = (inches * rpi).round
+
+      count.rows
+    end
   end
 end

--- a/gems/fiber_gauge/test/gauge_test.rb
+++ b/gems/fiber_gauge/test/gauge_test.rb
@@ -58,4 +58,20 @@ class FiberGaugeGaugeTest < Minitest::Test
 
     assert_equal 90.stitches, stitches
   end
+
+  # -----------------------------
+  # required_rows
+  # -----------------------------
+
+  def test_calculates_required_rows_for_height
+    rows = gauge.required_rows(10.inches)
+
+    assert_equal 60.rows, rows
+  end
+
+  def test_calculates_required_rows_for_metric_height
+    rows = gauge.required_rows(25.4.centimeters)
+
+    assert_equal 60.rows, rows
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `Gauge#required_rows(length)` that mirrors `required_stitches`
- Returns a `FiberUnits::RowCount` for a given target height
- Supports both inch and metric inputs via `fiber_units` conversion
- Also adds `rake` and `simplecov-json` to test group in Gemfile (were missing)

Closes #11

## Test plan
- [x] `bundle exec rake test` passes (7 tests, 9 assertions, 100% line coverage)
- [x] Tests cover inches and centimeters inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)