### PR TITLE
feat(fiber_gauge): add optional height: parameter to Gauge

### DIFF
--- a/gems/fiber_gauge/lib/fiber_gauge/gauge.rb
+++ b/gems/fiber_gauge/lib/fiber_gauge/gauge.rb
@@ -1,11 +1,12 @@
 module FiberGauge
   class Gauge
-    attr_reader :stitches, :rows, :width
+    attr_reader :stitches, :rows, :width, :height
 
-    def initialize(stitches:, rows:, width:)
+    def initialize(stitches:, rows:, width:, height: width)
       @stitches = stitches
       @rows = rows
       @width = width
+      @height = height
     end
 
     def spi
@@ -13,7 +14,7 @@ module FiberGauge
     end
 
     def rpi
-      rows.value / width.to(:inches).value
+      rows.value / height.to(:inches).value
     end
 
     def width_for_stitches(stitch_count)

--- a/gems/fiber_gauge/test/gauge_test.rb
+++ b/gems/fiber_gauge/test/gauge_test.rb
@@ -21,6 +21,19 @@ class FiberGaugeGaugeTest < Minitest::Test
     assert_equal 18, g.stitches.value
     assert_equal 24, g.rows.value
     assert_equal 4.inches, g.width
+    assert_equal 4.inches, g.height
+  end
+
+  def test_initialization_with_separate_height
+    g = FiberGauge::Gauge.new(
+      stitches: 18.stitches,
+      rows: 24.rows,
+      width: 4.inches,
+      height: 5.inches
+    )
+
+    assert_equal 4.inches, g.width
+    assert_equal 5.inches, g.height
   end
 
   # -----------------------------
@@ -37,6 +50,18 @@ class FiberGaugeGaugeTest < Minitest::Test
 
   def test_calculates_rpi
     assert_equal 6, gauge.rpi
+  end
+
+  def test_calculates_rpi_with_separate_height
+    g = FiberGauge::Gauge.new(
+      stitches: 18.stitches,
+      rows: 24.rows,
+      width: 4.inches,
+      height: 6.inches
+    )
+
+    assert_in_delta 4.0, g.rpi, 0.001
+    assert_equal 4.5, g.spi.round(2)
   end
 
   # -----------------------------


### PR DESCRIPTION
## Summary

- Add optional `height:` keyword argument to `FiberGauge::Gauge.new`, defaulting to `width`
- `spi` continues to use `width`; `rpi` now uses `height`
- Fully backward compatible — omitting `height` preserves existing behavior

## Test plan

- [x] Existing gauge tests pass (no behavior change when `height` omitted)
- [x] New test: initialization with separate height stores both values
- [x] New test: `rpi` uses height, `spi` still uses width
- [x] 100% line coverage maintained

Closes #18
Part of #12 (see also #19, #20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)