### PR TITLE
release: fiber_gauge v0.2.0

### DIFF
--- a/gems/fiber_gauge/CHANGELOG.md
+++ b/gems/fiber_gauge/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [Unreleased]
 
 
+## [0.2.0] - 2026-03-21
+
+### Added
+- Optional `height:` parameter on `Gauge.new` (defaults to `width`)
+- `rpi` now uses `height`; `spi` continues to use `width`
+- `required_rows` method for calculating row count from a target length
+
 ## [0.1.0] - 2026-03-14
 
 ### Changed

--- a/gems/fiber_gauge/lib/fiber_gauge/version.rb
+++ b/gems/fiber_gauge/lib/fiber_gauge/version.rb
@@ -2,6 +2,6 @@
 
 # :nocov:
 module FiberGauge
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end
 # :nocov:


### PR DESCRIPTION
## Summary

- Bump `FiberGauge::VERSION` to `0.2.0`
- Update CHANGELOG.md with v0.2.0 entry (height parameter, required_rows)
- Empty Unreleased section

## What's in this release

- Optional `height:` parameter on `Gauge.new` (defaults to `width`)
- `rpi` uses `height`; `spi` continues to use `width`
- `required_rows` method for calculating row count from a target length

## Test plan

- [x] Release readiness workflow validates branch name, version, and changelog format
- [x] Gem builds successfully on merge
- [x] Publishes to RubyGems automatically

Closes #19
Part of #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)