### PR TITLE
feat(gauge-calculator): simplify GaugeService to use single gauge with height

### DIFF
--- a/apps/gauge-calculator/Gemfile.lock
+++ b/apps/gauge-calculator/Gemfile.lock
@@ -63,8 +63,8 @@ GEM
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
-    fiber_gauge (0.1.0)
-      fiber_units (~> 0.3.1)
+    fiber_gauge (0.2.0)
+      fiber_units (>= 0.1)
     fiber_units (0.3.1)
     grade_runner (0.0.16)
       activesupport (>= 2.3.5)
@@ -246,7 +246,7 @@ CHECKSUMS
   faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
-  fiber_gauge (0.1.0) sha256=7ab6743d9ac20449c91736ead742fbfde6a0ad254449d5032323eb15c5ab9e78
+  fiber_gauge (0.2.0) sha256=89ac687ce519061f00ccb3a7ef2fc59bfbdb68151f2909c82f9845bffce1d46d
   fiber_units (0.3.1) sha256=4aa5688494b1315ecaa415a434f03a69faee155af4fcd1d57f3d000f4ed6df1a
   grade_runner (0.0.16) sha256=c12013854b0c814cb8cb2c0882203e4674642aa4bc2297462a8f896a2ee33fd2
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1

--- a/apps/gauge-calculator/app/services/gauge_service.rb
+++ b/apps/gauge-calculator/app/services/gauge_service.rb
@@ -6,19 +6,14 @@ class GaugeService
     @stitch_count = stitches
     @row_count = rows
 
-    @gauge = FiberGauge::Gauge.new(
+    gauge_opts = {
       stitches: stitches.stitches,
       rows: rows.rows,
       width: width.to_f.public_send(@unit)
-    )
+    }
+    gauge_opts[:height] = height.to_f.public_send(@unit) if height
 
-    if height
-      @row_gauge = FiberGauge::Gauge.new(
-        stitches: stitches.stitches,
-        rows: rows.rows,
-        width: height.to_f.public_send(@unit)
-      )
-    end
+    @gauge = FiberGauge::Gauge.new(**gauge_opts)
   end
 
   def spi
@@ -26,7 +21,7 @@ class GaugeService
   end
 
   def rpi
-    row_gauge.rpi
+    gauge.rpi
   end
 
   def results
@@ -45,8 +40,4 @@ class GaugeService
   end
 
   private
-
-  def row_gauge
-    @row_gauge || @gauge
-  end
 end

--- a/apps/gauge-calculator/test/api_test.rb
+++ b/apps/gauge-calculator/test/api_test.rb
@@ -29,13 +29,13 @@ class GaugeCalculatorApiTest < Minitest::Test
   end
 
   def test_post_api_gauge_uses_separate_height_for_rpi
-    width_gauge = Struct.new(:spi, :rpi).new(5.0, 7.0)
-    height_gauge = Struct.new(:spi, :rpi).new(5.0, 5.6)
-    call_count = 0
+    test_case = self
+    fake_gauge = Struct.new(:spi, :rpi).new(5.0, 5.6)
 
-    stub_class_method(FiberGauge::Gauge, :new, ->(**) {
-      call_count += 1
-      call_count == 1 ? width_gauge : height_gauge
+    stub_class_method(FiberGauge::Gauge, :new, ->(**kwargs) {
+      test_case.assert_equal 4.0, kwargs[:width].value
+      test_case.assert_equal 5.0, kwargs[:height].value
+      fake_gauge
     }) do
       request_post "/api/gauge",
         JSON.generate({stitches: 20, rows: 28, width: 4, height: 5}),

--- a/apps/gauge-calculator/test/gauge_service_test.rb
+++ b/apps/gauge-calculator/test/gauge_service_test.rb
@@ -39,25 +39,19 @@ class GaugeServiceTest < Minitest::Test
   end
 
   def test_rpi_uses_height_when_provided
-    call_count = 0
-    width_gauge = Struct.new(:spi, :rpi).new(5.0, 7.0)
-    height_gauge = Struct.new(:spi, :rpi).new(5.0, 6.0)
+    test_case = self
+    fake_gauge = Struct.new(:spi, :rpi).new(5.0, 6.0)
 
     stub_class_method(FiberGauge::Gauge, :new, ->(**kwargs) {
-      call_count += 1
-      if call_count == 1
-        width_gauge
-      else
-        height_gauge
-      end
+      test_case.assert_equal 4.0, kwargs[:width].value
+      test_case.assert_equal 5.0, kwargs[:height].value
+      fake_gauge
     }) do
       service = GaugeService.new(stitches: 20, rows: 28, width: 4, height: 5)
 
       assert_equal 5.0, service.spi
       assert_equal 6.0, service.rpi
     end
-
-    assert_equal 2, call_count
   end
 
   def test_rpi_uses_width_when_height_omitted


### PR DESCRIPTION
## Summary

- Update `fiber_gauge` gem to v0.2.0 (adds `height:` parameter)
- Simplify `GaugeService` to create a single `FiberGauge::Gauge` instance, passing `height:` directly instead of maintaining a separate `@row_gauge`
- Remove private `row_gauge` method

## Test plan

- [x] All 20 gauge-calculator tests pass
- [x] `GaugeService` tests verify `height:` is passed through to `Gauge.new`
- [x] API test verifies height is forwarded correctly from the endpoint

Closes #20
Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)