### PR TITLE
feat(yarn_skein): add Substitution class for finding compatible yarns

### DIFF
--- a/gems/yarn_skein/Gemfile
+++ b/gems/yarn_skein/Gemfile
@@ -6,5 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
+  gem "rake"
   gem "simplecov", require: false
+  gem "simplecov-json", require: false
 end

--- a/gems/yarn_skein/lib/yarn_skein.rb
+++ b/gems/yarn_skein/lib/yarn_skein.rb
@@ -5,6 +5,7 @@ require_relative "yarn_skein/version"
 require_relative "yarn_skein/weight_category"
 require_relative "yarn_skein/fiber_blend"
 require_relative "yarn_skein/yarn"
+require_relative "yarn_skein/substitution"
 
 # Domain objects for describing yarn skeins, fiber blends, and weight classes.
 #

--- a/gems/yarn_skein/lib/yarn_skein/substitution.rb
+++ b/gems/yarn_skein/lib/yarn_skein/substitution.rb
@@ -1,0 +1,30 @@
+module YarnSkein
+  class Substitution
+    DEFAULT_TOLERANCE = 0.15
+
+    attr_reader :target, :catalog
+
+    def initialize(target:, catalog:)
+      @target = target
+      @catalog = catalog
+    end
+
+    def matches(tolerance: DEFAULT_TOLERANCE, fiber: nil)
+      catalog.select do |yarn|
+        next false if yarn == target
+        next false unless yarn.weight_category == target.weight_category
+        next false unless within_grist_tolerance?(yarn, tolerance)
+        next false if fiber && !yarn.fiber_content&.contains?(fiber)
+
+        true
+      end
+    end
+
+    private
+
+    def within_grist_tolerance?(yarn, tolerance)
+      ratio = yarn.yards_per_100g / target.yards_per_100g.to_f
+      ratio.between?(1.0 - tolerance, 1.0 + tolerance)
+    end
+  end
+end

--- a/gems/yarn_skein/test/substitution_test.rb
+++ b/gems/yarn_skein/test/substitution_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class YarnSkeinSubstitutionTest < Minitest::Test
+  def build_yarn(line:, yardage:, skein_weight:, fiber_content: nil)
+    YarnSkein::Yarn.new(
+      brand: "TestBrand",
+      line: line,
+      yardage: yardage,
+      skein_weight: skein_weight,
+      fiber_content: fiber_content
+    )
+  end
+
+  def target_yarn
+    @target_yarn ||= build_yarn(line: "Target", yardage: 210.yards, skein_weight: 100.grams)
+  end
+
+  # 210 yards/100g => worsted, yards_per_100g = 210
+
+  def close_match
+    @close_match ||= build_yarn(line: "Close", yardage: 200.yards, skein_weight: 100.grams)
+  end
+
+  def exact_match
+    @exact_match ||= build_yarn(line: "Exact", yardage: 210.yards, skein_weight: 100.grams)
+  end
+
+  def too_far
+    @too_far ||= build_yarn(line: "TooFar", yardage: 300.yards, skein_weight: 100.grams)
+  end
+
+  def different_category
+    @different_category ||= build_yarn(line: "Bulky", yardage: 120.yards, skein_weight: 100.grams)
+  end
+
+  def wool_yarn
+    @wool_yarn ||= build_yarn(
+      line: "Wool",
+      yardage: 200.yards,
+      skein_weight: 100.grams,
+      fiber_content: YarnSkein::FiberBlend.new(wool: 100)
+    )
+  end
+
+  def cotton_yarn
+    @cotton_yarn ||= build_yarn(
+      line: "Cotton",
+      yardage: 200.yards,
+      skein_weight: 100.grams,
+      fiber_content: YarnSkein::FiberBlend.new(cotton: 100)
+    )
+  end
+
+  # -----------------------------
+  # matches
+  # -----------------------------
+
+  def test_returns_yarns_matching_weight_category_and_grist
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [close_match, too_far])
+
+    assert_equal [close_match], sub.matches
+  end
+
+  def test_excludes_target_yarn_from_results
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [target_yarn, close_match])
+
+    assert_equal [close_match], sub.matches
+  end
+
+  def test_excludes_different_weight_category
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [different_category])
+
+    assert_empty sub.matches
+  end
+
+  def test_returns_empty_for_empty_catalog
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [])
+
+    assert_empty sub.matches
+  end
+
+  def test_returns_empty_when_no_matches
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [too_far, different_category])
+
+    assert_empty sub.matches
+  end
+
+  # -----------------------------
+  # tolerance
+  # -----------------------------
+
+  def test_configurable_tolerance
+    # close_match is 200/210 = ~0.952, within 15% but outside 2%
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [close_match])
+
+    assert_equal [close_match], sub.matches(tolerance: 0.15)
+    assert_empty sub.matches(tolerance: 0.02)
+  end
+
+  # -----------------------------
+  # fiber filter
+  # -----------------------------
+
+  def test_filters_by_fiber_content
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [wool_yarn, cotton_yarn])
+
+    assert_equal [wool_yarn], sub.matches(fiber: :wool)
+  end
+
+  def test_fiber_filter_excludes_yarns_without_fiber_content
+    yarn_no_fiber = build_yarn(line: "NoFiber", yardage: 200.yards, skein_weight: 100.grams)
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [yarn_no_fiber, wool_yarn])
+
+    assert_equal [wool_yarn], sub.matches(fiber: :wool)
+  end
+
+  def test_includes_exact_grist_match
+    sub = YarnSkein::Substitution.new(target: target_yarn, catalog: [exact_match])
+
+    assert_equal [exact_match], sub.matches
+  end
+end


### PR DESCRIPTION
## Summary

- Add `YarnSkein::Substitution` class that finds compatible yarn substitutes from a catalog
- Matches by weight category and grist tolerance (default 15%, configurable)
- Optional fiber content filter
- Excludes the target yarn from results
- Also fixes missing `rake` and `simplecov-json` dev deps in yarn_skein Gemfile

## Usage

```ruby
sub = YarnSkein::Substitution.new(target: my_yarn, catalog: all_yarns)
sub.matches                    # weight category + grist within 15%
sub.matches(tolerance: 0.10)   # tighter grist match
sub.matches(fiber: :wool)      # also filter by fiber
```

## Test plan

- [x] Returns yarns matching weight category and grist tolerance
- [x] Excludes target yarn from results
- [x] Excludes different weight categories
- [x] Empty catalog returns empty
- [x] No matches returns empty
- [x] Configurable tolerance (tight vs loose)
- [x] Fiber content filter works
- [x] Yarns without fiber_content excluded when fiber filter active
- [x] 100% line and branch coverage

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)