### PR TITLE
Update gemspec files for consistent repository URL format

### DIFF
--- a/gems/fiber_gauge/fiber_gauge.gemspec
+++ b/gems/fiber_gauge/fiber_gauge.gemspec
@@ -2,22 +2,26 @@
 
 require_relative "lib/fiber_gauge/version"
 
+lib_name = "fiber_gauge"
+monorepo_url = "https://github.com/meaganewaller/craftos"
+repository_url = "#{monorepo_url}/tree/main/gems/#{lib_name}"
+
 Gem::Specification.new do |spec|
-  spec.name = "fiber_gauge"
+  spec.name = lib_name
   spec.version = FiberGauge::VERSION
   spec.authors = ["Meagan Waller"]
   spec.email = ["meagan@meaganwaller.com"]
 
   spec.summary = "A gem for measuring fiber usage in Ruby applications."
   spec.description = "FiberGauge is a Ruby gem that provides tools to measure and analyze fiber usage in Ruby applications."
-  spec.homepage = "https://github.com/meaganewaller/fiber_gauge"
+  spec.homepage = repository_url
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/meaganewaller/fiber_gauge"
-  spec.metadata["changelog_uri"] = "https://github.com/meaganewaller/fiber_gauge/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = repository_url
+  spec.metadata["changelog_uri"] = "#{repository_url}/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/gems/fiber_pattern/fiber_pattern.gemspec
+++ b/gems/fiber_pattern/fiber_pattern.gemspec
@@ -3,7 +3,8 @@
 lib_name = "fiber_pattern"
 
 require_relative "lib/fiber_pattern/version"
-repository_url = "https://github.com/meaganewaller/#{lib_name}"
+monorepo_url = "https://github.com/meaganewaller/craftos"
+repository_url = "#{monorepo_url}/tree/main/gems/#{lib_name}"
 
 Gem::Specification.new do |spec|
   spec.summary = "Pattern sizing and stitch math for knitting and crochet."
@@ -15,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "source_code_uri" => repository_url,
-    "bug_tracker_uri" => "#{repository_url}/issues",
+    "bug_tracker_uri" => "#{monorepo_url}/issues",
     "rubygems_mfa_required" => "true"
   }
 

--- a/gems/fiber_units/fiber_units.gemspec
+++ b/gems/fiber_units/fiber_units.gemspec
@@ -2,22 +2,26 @@
 
 require_relative "lib/fiber_units/version"
 
+lib_name = "fiber_units"
+monorepo_url = "https://github.com/meaganewaller/craftos"
+repository_url = "#{monorepo_url}/tree/main/gems/#{lib_name}"
+
 Gem::Specification.new do |spec|
-  spec.name = "fiber_units"
+  spec.name = lib_name
   spec.version = FiberUnits::VERSION
   spec.authors = ["Meagan Waller"]
   spec.email = ["meagan@meaganwaller.com"]
 
   spec.summary = "Typed measurement units for fiber arts."
   spec.description = "A Ruby gem providing typed measurement units for various fiber arts, allowing for easy conversion and manipulation of units like yards and meters."
-  spec.homepage = "https://github.com/meaganewaller/craftos/tree/main/gems/fiber_units"
+  spec.homepage = repository_url
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.4.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/meaganewaller/craftos/tree/main/gems/fiber_units"
-  spec.metadata["changelog_uri"] = "https://github.com/meaganewaller/craftos/blob/main/gems/fiber_units/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = repository_url
+  spec.metadata["changelog_uri"] = "#{repository_url}/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/gems/yarn_skein/yarn_skein.gemspec
+++ b/gems/yarn_skein/yarn_skein.gemspec
@@ -2,22 +2,26 @@
 
 require_relative "lib/yarn_skein/version"
 
+lib_name = "yarn_skein"
+monorepo_url = "https://github.com/meaganewaller/craftos"
+repository_url = "#{monorepo_url}/tree/main/gems/#{lib_name}"
+
 Gem::Specification.new do |spec|
-  spec.name = "yarn_skein"
+  spec.name = lib_name
   spec.version = YarnSkein::VERSION
   spec.authors = ["Meagan Waller"]
   spec.email = ["meagan@meaganwaller.com"]
 
   spec.summary = "Typed measurements for fiber arts."
   spec.description = "FiberUnits provides a comprehensive system for managing and converting measurements in fiber arts projects."
-  spec.homepage = "https://github.com/meaganewaller/yarn_skein"
+  spec.homepage = repository_url
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/meaganewaller/yarn_skein"
-  spec.metadata["changelog_uri"] = "https://github.com/meaganewaller/yarn_skein/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = repository_url
+  spec.metadata["changelog_uri"] = "#{repository_url}/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Standardize the repository URL format across multiple gemspec files to improve clarity and maintainability. This change ensures all gems reference the correct monorepo structure.