### PR TITLE
feat(fiber_pattern): add garment sizing engine

### DIFF
--- a/gems/fiber_pattern/lib/fiber_pattern.rb
+++ b/gems/fiber_pattern/lib/fiber_pattern.rb
@@ -9,6 +9,10 @@ require_relative "fiber_pattern/scaling"
 require_relative "fiber_pattern/shaping"
 require_relative "fiber_pattern/grade_rules"
 require_relative "fiber_pattern/grader"
+require_relative "fiber_pattern/body_measurements"
+require_relative "fiber_pattern/ease"
+require_relative "fiber_pattern/garment_sizing"
+require_relative "fiber_pattern/size_chart"
 
 # Utilities for generating fiber pattern measurements from gauge data.
 module FiberPattern

--- a/gems/fiber_pattern/lib/fiber_pattern/body_measurements.rb
+++ b/gems/fiber_pattern/lib/fiber_pattern/body_measurements.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module FiberPattern
+  # Value object representing key body dimensions.
+  #
+  # Accepts any set of named measurements as keyword arguments.
+  # Each value should be a FiberUnits::Length.
+  #
+  # @example
+  #   body = FiberPattern::BodyMeasurements.new(
+  #     bust: 36.inches,
+  #     waist: 30.inches,
+  #     hip: 38.inches,
+  #     arm_length: 24.inches
+  #   )
+  #   body.bust       # => 36.inches
+  #   body[:waist]    # => 30.inches
+  #   body.measurements # => [:bust, :waist, :hip, :arm_length]
+  class BodyMeasurements
+    # @return [Hash<Symbol, FiberUnits::Length>] all measurements
+    attr_reader :data
+
+    # @param measurements [Hash<Symbol, FiberUnits::Length>] named body measurements
+    def initialize(**measurements)
+      raise ArgumentError, "at least one measurement is required" if measurements.empty?
+
+      @data = measurements.freeze
+      define_accessors!
+    end
+
+    # Returns the measurement names.
+    #
+    # @return [Array<Symbol>]
+    def measurements
+      data.keys
+    end
+
+    # Hash-style access to a measurement.
+    #
+    # @param name [Symbol]
+    # @return [FiberUnits::Length, nil]
+    def [](name)
+      data[name]
+    end
+
+    # Returns measurements as a plain hash.
+    #
+    # @return [Hash<Symbol, FiberUnits::Length>]
+    def to_h
+      data.dup
+    end
+
+    private
+
+    def define_accessors!
+      data.each_key do |name|
+        define_singleton_method(name) { data[name] }
+      end
+    end
+  end
+end

--- a/gems/fiber_pattern/lib/fiber_pattern/ease.rb
+++ b/gems/fiber_pattern/lib/fiber_pattern/ease.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module FiberPattern
+  # Value object representing ease preferences per measurement.
+  #
+  # Ease is the difference between body measurements and finished garment
+  # measurements. Positive ease creates a looser fit; negative ease creates
+  # a tighter fit.
+  #
+  # @example
+  #   ease = FiberPattern::Ease.new(
+  #     bust: 4.inches,
+  #     waist: 2.inches,
+  #     hip: 2.inches
+  #   )
+  #   ease.bust        # => 4.inches
+  #   ease[:waist]     # => 2.inches
+  #   ease.for(:bust)  # => 4.inches
+  class Ease
+    # @return [Hash<Symbol, FiberUnits::Length>] all ease values
+    attr_reader :data
+
+    # @param ease_values [Hash<Symbol, FiberUnits::Length>] named ease values
+    def initialize(**ease_values)
+      raise ArgumentError, "at least one ease value is required" if ease_values.empty?
+
+      @data = ease_values.freeze
+      define_accessors!
+    end
+
+    # Returns the ease value for a given measurement.
+    #
+    # @param name [Symbol]
+    # @return [FiberUnits::Length]
+    # @raise [ArgumentError] if no ease is defined for the measurement
+    def for(name)
+      raise ArgumentError, "no ease defined for #{name.inspect}" unless data.key?(name)
+
+      data[name]
+    end
+
+    # Hash-style access to an ease value.
+    #
+    # @param name [Symbol]
+    # @return [FiberUnits::Length, nil]
+    def [](name)
+      data[name]
+    end
+
+    # Returns all measurement names that have ease defined.
+    #
+    # @return [Array<Symbol>]
+    def measurements
+      data.keys
+    end
+
+    # Returns ease values as a plain hash.
+    #
+    # @return [Hash<Symbol, FiberUnits::Length>]
+    def to_h
+      data.dup
+    end
+
+    private
+
+    def define_accessors!
+      data.each_key do |name|
+        next if name == :for # avoid overriding #for
+
+        define_singleton_method(name) { data[name] }
+      end
+    end
+  end
+end

--- a/gems/fiber_pattern/lib/fiber_pattern/garment_sizing.rb
+++ b/gems/fiber_pattern/lib/fiber_pattern/garment_sizing.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module FiberPattern
+  # Combines body measurements with ease to produce finished garment dimensions.
+  #
+  # @example
+  #   body = FiberPattern::BodyMeasurements.new(bust: 36.inches, waist: 30.inches)
+  #   ease = FiberPattern::Ease.new(bust: 4.inches, waist: 2.inches)
+  #   garment = FiberPattern::GarmentSizing.new(body: body, ease: ease)
+  #   garment.bust   # => 40.inches
+  #   garment.waist  # => 32.inches
+  class GarmentSizing
+    # @return [FiberPattern::BodyMeasurements]
+    attr_reader :body
+
+    # @return [FiberPattern::Ease]
+    attr_reader :ease
+
+    # @param body [FiberPattern::BodyMeasurements] body measurements
+    # @param ease [FiberPattern::Ease] ease preferences
+    def initialize(body:, ease:)
+      validate!(body, ease)
+      @body = body
+      @ease = ease
+      define_accessors!
+    end
+
+    # Returns the finished garment dimension for a given measurement.
+    #
+    # @param name [Symbol]
+    # @return [FiberUnits::Length] body measurement + ease
+    # @raise [ArgumentError] if the measurement is not defined
+    def dimension(name)
+      raise ArgumentError, "unknown measurement #{name.inspect}" unless body.data.key?(name)
+
+      body[name] + (ease[name] || zero_length(body[name]))
+    end
+
+    # Hash-style access to finished dimensions.
+    #
+    # @param name [Symbol]
+    # @return [FiberUnits::Length]
+    def [](name)
+      dimension(name)
+    end
+
+    # Returns all finished garment dimensions.
+    #
+    # @return [Hash<Symbol, FiberUnits::Length>]
+    def dimensions
+      body.measurements.each_with_object({}) do |name, result|
+        result[name] = dimension(name)
+      end
+    end
+
+    private
+
+    def validate!(body, ease)
+      ease.measurements.each do |name|
+        unless body.measurements.include?(name)
+          raise ArgumentError, "ease defines #{name.inspect} but body measurements does not"
+        end
+      end
+    end
+
+    def define_accessors!
+      body.measurements.each do |name|
+        define_singleton_method(name) { dimension(name) }
+      end
+    end
+
+    def zero_length(reference)
+      reference * 0
+    end
+  end
+end

--- a/gems/fiber_pattern/lib/fiber_pattern/size_chart.rb
+++ b/gems/fiber_pattern/lib/fiber_pattern/size_chart.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module FiberPattern
+  # Standard size chart based on Craft Yarn Council (CYC) guidelines.
+  #
+  # Provides lookup of standard body measurements by size, and a closest-size
+  # finder that matches body measurements to the nearest standard size.
+  #
+  # @example
+  #   chart = FiberPattern::SizeChart.new
+  #   chart.size(:m)          # => { bust: 36.inches, waist: 28.inches, hip: 38.inches }
+  #   chart.closest_size(bust: 37.inches, waist: 29.inches, hip: 39.inches) # => :m
+  class SizeChart
+    # CYC standard women's body measurements (inches).
+    # Source: Craft Yarn Council Standards & Guidelines
+    CYC_WOMEN = {
+      xs: {bust: 28, waist: 20, hip: 30},
+      s: {bust: 32, waist: 24, hip: 34},
+      m: {bust: 36, waist: 28, hip: 38},
+      l: {bust: 40, waist: 32, hip: 42},
+      xl: {bust: 44, waist: 36, hip: 46},
+      xxl: {bust: 48, waist: 40, hip: 50},
+      xxxl: {bust: 52, waist: 44, hip: 54},
+      xxxxl: {bust: 56, waist: 48, hip: 58},
+      xxxxxl: {bust: 60, waist: 52, hip: 62}
+    }.freeze
+
+    # @return [Hash<Symbol, Hash<Symbol, FiberUnits::Length>>] size chart data
+    attr_reader :chart
+
+    # @return [Array<Symbol>] ordered size names
+    attr_reader :sizes
+
+    # Creates a new size chart.
+    #
+    # @param chart [Hash<Symbol, Hash<Symbol, Numeric>>] raw chart data mapping size names
+    #   to measurement hashes. Values are converted to inches. Defaults to CYC_WOMEN.
+    def initialize(chart: CYC_WOMEN)
+      @chart = chart.each_with_object({}) do |(size_name, measurements), result|
+        result[size_name] = measurements.transform_values { |v| v.is_a?(Numeric) ? v.inches : v }
+      end.freeze
+      @sizes = @chart.keys.freeze
+    end
+
+    # Returns body measurements for a standard size.
+    #
+    # @param name [Symbol] size name
+    # @return [Hash<Symbol, FiberUnits::Length>]
+    # @raise [ArgumentError] if the size is not in the chart
+    def size(name)
+      raise ArgumentError, "unknown size #{name.inspect}" unless chart.key?(name)
+
+      chart[name]
+    end
+
+    # Finds the closest standard size to the given body measurements.
+    #
+    # Compares using the sum of squared differences across all provided
+    # measurements. Only measurements present in both the query and the
+    # chart are compared.
+    #
+    # @param measurements [Hash<Symbol, FiberUnits::Length>] body measurements to match
+    # @return [Symbol] the closest size name
+    # @raise [ArgumentError] if no measurements overlap with the chart
+    def closest_size(**measurements)
+      comparable_keys = measurements.keys & chart.values.first.keys
+      raise ArgumentError, "no comparable measurements provided" if comparable_keys.empty?
+
+      sizes.min_by do |size_name|
+        size_data = chart[size_name]
+        comparable_keys.sum do |key|
+          diff = measurements[key].value - size_data[key].value
+          diff * diff
+        end
+      end
+    end
+
+    # Returns a BodyMeasurements object for a standard size.
+    #
+    # @param name [Symbol] size name
+    # @return [FiberPattern::BodyMeasurements]
+    def body_measurements_for(name)
+      BodyMeasurements.new(**size(name))
+    end
+  end
+end

--- a/gems/fiber_pattern/test/body_measurements_test.rb
+++ b/gems/fiber_pattern/test/body_measurements_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FiberPatternBodyMeasurementsTest < Minitest::Test
+  def body
+    FiberPattern::BodyMeasurements.new(
+      bust: 36.inches,
+      waist: 30.inches,
+      hip: 38.inches,
+      arm_length: 24.inches
+    )
+  end
+
+  # -----------------------------
+  # accessors
+  # -----------------------------
+
+  def test_accessor_methods_return_measurements
+    assert_equal 36.inches, body.bust
+    assert_equal 30.inches, body.waist
+    assert_equal 38.inches, body.hip
+    assert_equal 24.inches, body.arm_length
+  end
+
+  def test_bracket_access_returns_measurement
+    assert_equal 36.inches, body[:bust]
+    assert_equal 30.inches, body[:waist]
+  end
+
+  def test_bracket_access_returns_nil_for_unknown
+    assert_nil body[:inseam]
+  end
+
+  # -----------------------------
+  # measurements
+  # -----------------------------
+
+  def test_measurements_returns_all_keys
+    assert_equal %i[bust waist hip arm_length], body.measurements
+  end
+
+  # -----------------------------
+  # to_h
+  # -----------------------------
+
+  def test_to_h_returns_hash_of_measurements
+    result = body.to_h
+
+    assert_equal 36.inches, result[:bust]
+    assert_equal 30.inches, result[:waist]
+    assert_equal 38.inches, result[:hip]
+    assert_equal 24.inches, result[:arm_length]
+  end
+
+  # -----------------------------
+  # validation
+  # -----------------------------
+
+  def test_raises_when_no_measurements_given
+    assert_raises(ArgumentError) { FiberPattern::BodyMeasurements.new }
+  end
+
+  # -----------------------------
+  # immutability
+  # -----------------------------
+
+  def test_data_is_frozen
+    assert body.data.frozen?
+  end
+end

--- a/gems/fiber_pattern/test/ease_test.rb
+++ b/gems/fiber_pattern/test/ease_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FiberPatternEaseTest < Minitest::Test
+  def ease
+    FiberPattern::Ease.new(
+      bust: 4.inches,
+      waist: 2.inches,
+      hip: 2.inches
+    )
+  end
+
+  # -----------------------------
+  # accessors
+  # -----------------------------
+
+  def test_accessor_methods_return_ease_values
+    assert_equal 4.inches, ease.bust
+    assert_equal 2.inches, ease.waist
+    assert_equal 2.inches, ease.hip
+  end
+
+  def test_bracket_access_returns_ease_value
+    assert_equal 4.inches, ease[:bust]
+  end
+
+  def test_bracket_access_returns_nil_for_unknown
+    assert_nil ease[:inseam]
+  end
+
+  # -----------------------------
+  # for
+  # -----------------------------
+
+  def test_for_returns_ease_value
+    assert_equal 4.inches, ease.for(:bust)
+  end
+
+  def test_for_raises_for_unknown_measurement
+    assert_raises(ArgumentError) { ease.for(:inseam) }
+  end
+
+  # -----------------------------
+  # measurements
+  # -----------------------------
+
+  def test_measurements_returns_all_keys
+    assert_equal %i[bust waist hip], ease.measurements
+  end
+
+  # -----------------------------
+  # negative ease
+  # -----------------------------
+
+  def test_negative_ease_values
+    negative = FiberPattern::Ease.new(bust: -2.inches)
+
+    assert_equal(-2.inches, negative.bust)
+  end
+
+  # -----------------------------
+  # validation
+  # -----------------------------
+
+  def test_raises_when_no_ease_values_given
+    assert_raises(ArgumentError) { FiberPattern::Ease.new }
+  end
+
+  # -----------------------------
+  # immutability
+  # -----------------------------
+
+  def test_data_is_frozen
+    assert ease.data.frozen?
+  end
+end

--- a/gems/fiber_pattern/test/garment_sizing_test.rb
+++ b/gems/fiber_pattern/test/garment_sizing_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FiberPatternGarmentSizingTest < Minitest::Test
+  def body
+    FiberPattern::BodyMeasurements.new(
+      bust: 36.inches,
+      waist: 30.inches,
+      hip: 38.inches
+    )
+  end
+
+  def ease
+    FiberPattern::Ease.new(
+      bust: 4.inches,
+      waist: 2.inches,
+      hip: 2.inches
+    )
+  end
+
+  def garment
+    FiberPattern::GarmentSizing.new(body: body, ease: ease)
+  end
+
+  # -----------------------------
+  # dimension
+  # -----------------------------
+
+  def test_dimension_adds_body_and_ease
+    assert_equal 40.inches, garment.dimension(:bust)
+    assert_equal 32.inches, garment.dimension(:waist)
+    assert_equal 40.inches, garment.dimension(:hip)
+  end
+
+  def test_dimension_raises_for_unknown_measurement
+    assert_raises(ArgumentError) { garment.dimension(:inseam) }
+  end
+
+  # -----------------------------
+  # accessors
+  # -----------------------------
+
+  def test_accessor_methods_return_finished_dimensions
+    assert_equal 40.inches, garment.bust
+    assert_equal 32.inches, garment.waist
+    assert_equal 40.inches, garment.hip
+  end
+
+  # -----------------------------
+  # bracket access
+  # -----------------------------
+
+  def test_bracket_access_returns_finished_dimension
+    assert_equal 40.inches, garment[:bust]
+  end
+
+  # -----------------------------
+  # dimensions
+  # -----------------------------
+
+  def test_dimensions_returns_all_finished_measurements
+    result = garment.dimensions
+
+    assert_equal 40.inches, result[:bust]
+    assert_equal 32.inches, result[:waist]
+    assert_equal 40.inches, result[:hip]
+  end
+
+  # -----------------------------
+  # partial ease
+  # -----------------------------
+
+  def test_body_measurement_without_ease_uses_body_value
+    partial_ease = FiberPattern::Ease.new(bust: 4.inches)
+    g = FiberPattern::GarmentSizing.new(body: body, ease: partial_ease)
+
+    assert_equal 40.inches, g.bust
+    assert_equal 30.inches, g.waist
+    assert_equal 38.inches, g.hip
+  end
+
+  # -----------------------------
+  # negative ease
+  # -----------------------------
+
+  def test_negative_ease_subtracts_from_body
+    tight_ease = FiberPattern::Ease.new(bust: -2.inches)
+    g = FiberPattern::GarmentSizing.new(body: body, ease: tight_ease)
+
+    assert_equal 34.inches, g.bust
+  end
+
+  # -----------------------------
+  # validation
+  # -----------------------------
+
+  def test_raises_when_ease_has_measurement_not_in_body
+    bad_ease = FiberPattern::Ease.new(inseam: 2.inches)
+
+    assert_raises(ArgumentError) do
+      FiberPattern::GarmentSizing.new(body: body, ease: bad_ease)
+    end
+  end
+end

--- a/gems/fiber_pattern/test/size_chart_test.rb
+++ b/gems/fiber_pattern/test/size_chart_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FiberPatternSizeChartTest < Minitest::Test
+  def chart
+    FiberPattern::SizeChart.new
+  end
+
+  # -----------------------------
+  # size
+  # -----------------------------
+
+  def test_size_returns_measurements_for_standard_size
+    result = chart.size(:m)
+
+    assert_equal 36.inches, result[:bust]
+    assert_equal 28.inches, result[:waist]
+    assert_equal 38.inches, result[:hip]
+  end
+
+  def test_size_returns_measurements_for_xs
+    result = chart.size(:xs)
+
+    assert_equal 28.inches, result[:bust]
+    assert_equal 20.inches, result[:waist]
+    assert_equal 30.inches, result[:hip]
+  end
+
+  def test_size_returns_measurements_for_xl
+    result = chart.size(:xl)
+
+    assert_equal 44.inches, result[:bust]
+    assert_equal 36.inches, result[:waist]
+    assert_equal 46.inches, result[:hip]
+  end
+
+  def test_size_raises_for_unknown_size
+    assert_raises(ArgumentError) { chart.size(:jumbo) }
+  end
+
+  # -----------------------------
+  # sizes
+  # -----------------------------
+
+  def test_sizes_returns_all_size_names
+    expected = %i[xs s m l xl xxl xxxl xxxxl xxxxxl]
+
+    assert_equal expected, chart.sizes
+  end
+
+  # -----------------------------
+  # closest_size
+  # -----------------------------
+
+  def test_closest_size_returns_exact_match
+    assert_equal :m, chart.closest_size(bust: 36.inches, waist: 28.inches, hip: 38.inches)
+  end
+
+  def test_closest_size_returns_nearest_size
+    assert_equal :m, chart.closest_size(bust: 37.inches, waist: 29.inches, hip: 39.inches)
+  end
+
+  def test_closest_size_with_single_measurement
+    assert_equal :l, chart.closest_size(bust: 40.inches)
+  end
+
+  def test_closest_size_between_sizes_picks_closer
+    assert_equal :s, chart.closest_size(bust: 33.inches)
+  end
+
+  def test_closest_size_raises_with_no_comparable_measurements
+    assert_raises(ArgumentError) { chart.closest_size(inseam: 30.inches) }
+  end
+
+  # -----------------------------
+  # body_measurements_for
+  # -----------------------------
+
+  def test_body_measurements_for_returns_body_measurements_object
+    result = chart.body_measurements_for(:m)
+
+    assert_instance_of FiberPattern::BodyMeasurements, result
+    assert_equal 36.inches, result.bust
+    assert_equal 28.inches, result.waist
+    assert_equal 38.inches, result.hip
+  end
+
+  # -----------------------------
+  # custom chart
+  # -----------------------------
+
+  def test_custom_chart_data
+    custom = FiberPattern::SizeChart.new(chart: {
+      small: {chest: 34, length: 28},
+      large: {chest: 42, length: 30}
+    })
+
+    assert_equal 34.inches, custom.size(:small)[:chest]
+    assert_equal 42.inches, custom.size(:large)[:chest]
+    assert_equal %i[small large], custom.sizes
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `BodyMeasurements` value object for modeling body dimensions (bust, waist, hip, etc.)
- Adds `Ease` value object for defining ease preferences per measurement (positive/negative)
- Adds `GarmentSizing` class that combines body + ease into finished garment dimensions
- Adds `SizeChart` with CYC (Craft Yarn Council) standard women's sizes and a closest-size finder

## Motivation

Closes #34 — converting body measurements into garment dimensions requires understanding ease. This module bridges the gap between body measurements and the stitch/row counts that `fiber_pattern` already calculates.

## API

```ruby
body = FiberPattern::BodyMeasurements.new(bust: 36.inches, waist: 30.inches, hip: 38.inches)
ease = FiberPattern::Ease.new(bust: 4.inches, waist: 2.inches, hip: 2.inches)
garment = FiberPattern::GarmentSizing.new(body: body, ease: ease)
garment.bust   # => 40.inches

chart = FiberPattern::SizeChart.new
chart.closest_size(bust: 37.inches) # => :m
```

## Test plan

- [x] 76 tests pass (127 assertions), 0 failures
- [x] 99.55% line coverage, 95.65% branch coverage
- [x] StandardRB linting passes on all new files
- [x] All existing gem test suites continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)