### PR TITLE
Update production configuration for protection settings

### DIFF
--- a/apps/gauge-calculator/app.rb
+++ b/apps/gauge-calculator/app.rb
@@ -10,6 +10,10 @@ class GaugeCalculatorApp < Sinatra::Base
     set :environment, ENV.fetch("SINATRA_ENV", "development").to_sym
   end
 
+  configure :production do
+    set :protection, except: :host_authorization
+  end
+
   configure :test do
     set :protection, except: :host_authorization
   end


### PR DESCRIPTION
Adjust the production configuration to set specific protection settings for the GaugeCalculator application.