### PR TITLE
release(yarn_skein): v0.3.0

### DIFF
--- a/gems/yarn_skein/CHANGELOG.md
+++ b/gems/yarn_skein/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-26
+
 ### Added
+- `YarnSkein::Catalog` for loading yarn data from YAML seed files with filtering by brand, weight category, and fiber content
 - `YarnSkein::YardageEstimator` for estimating total yarn yardage from gauge and dimensions
 - Rectangular piece estimation via `for_rectangle(width:, height:)`
 - Stitch/row count estimation via `for_piece(stitches:, rows:)`

--- a/gems/yarn_skein/lib/yarn_skein/version.rb
+++ b/gems/yarn_skein/lib/yarn_skein/version.rb
@@ -3,6 +3,6 @@
 # :nocov:
 module YarnSkein
   # Current gem version.
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end
 # :nocov:


### PR DESCRIPTION
## Summary

Release `yarn_skein` v0.3.0.

### Changes

- `YarnSkein::Catalog` for loading yarn data from YAML seed files with filtering by brand, weight category, and fiber content
- `YarnSkein::YardageEstimator` for estimating total yarn yardage from gauge and dimensions
- Rectangular piece estimation via `for_rectangle(width:, height:)`
- Stitch/row count estimation via `for_piece(stitches:, rows:)`
- Configurable safety margin (default 10%) for waste and joining
- Added `fiber_gauge` as a runtime dependency

## Checklist

- [x] Version bumped in `version.rb`
- [x] Changelog updated with release date
- [x] `[Unreleased]` section is empty
- [x] Tests pass
- [x] Branch follows `release/<gem>-v<version>` convention

> Merging this PR will trigger the release workflow to publish to RubyGems and create a GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)