### PR TITLE
release(fiber_pattern): v0.5.0

### DIFF
--- a/gems/fiber_pattern/CHANGELOG.md
+++ b/gems/fiber_pattern/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## [0.5.0] - 2026-03-26
+
 ### Added
 
 - Add `StitchPattern` class for modeling how stitch patterns affect fabric width and yarn consumption relative to stockinette

--- a/gems/fiber_pattern/lib/fiber_pattern/version.rb
+++ b/gems/fiber_pattern/lib/fiber_pattern/version.rb
@@ -3,6 +3,6 @@
 # :nocov:
 module FiberPattern
   # Current gem version.
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end
 # :nocov:


### PR DESCRIPTION
## Summary

Release `fiber_pattern` v0.5.0.

### Changes

- Add `StitchPattern` class for modeling how stitch patterns affect fabric width and yarn consumption relative to stockinette
- Add knitting presets: stockinette, garter, 1x1 rib, 2x2 rib, seed stitch
- Add crochet presets: single crochet, half double crochet, double crochet, treble crochet, moss stitch, shell stitch, v-stitch
- Add `stitch_pattern` option to `Sizing` for width-adjusted cast-on calculations

## Checklist

- [x] Version bumped in `version.rb`
- [x] Changelog updated with release date
- [x] `[Unreleased]` section is empty
- [x] Tests pass
- [x] Branch follows `release/<gem>-v<version>` convention

> Merging this PR will trigger the release workflow to publish to RubyGems and create a GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)