### PR TITLE
feat(pattern-editor): add multi-piece project endpoint

### DIFF
--- a/apps/pattern-editor/app.rb
+++ b/apps/pattern-editor/app.rb
@@ -27,6 +27,30 @@ class PatternEditorApp < Sinatra::Base
     PieceService.stitch_pattern_list.to_json
   end
 
+  post "/api/project" do
+    content_type :json
+    validate_gauge_params!
+    validate_project_pieces_params!
+
+    pieces = request_params["pieces"].map do |piece_def|
+      shaping = piece_def["shaping"]
+      validate_shaping_hash!(shaping) if shaping
+
+      service = PieceService.new(
+        gauge_params: request_params.fetch("gauge"),
+        piece_params: piece_def,
+        stitch_pattern_name: request_params["stitch_pattern"],
+        repeat_params: request_params["repeat"],
+        unit: request_params.dig("gauge", "unit"),
+        shaping_params: shaping
+      )
+
+      {name: piece_def["name"]}.merge(service.results)
+    end
+
+    {pieces: pieces}.to_json
+  end
+
   post "/api/piece" do
     content_type :json
     validate_gauge_params!
@@ -76,6 +100,10 @@ class PatternEditorApp < Sinatra::Base
     shaping = request_params["shaping"]
     return if shaping.nil?
 
+    validate_shaping_hash!(shaping)
+  end
+
+  def validate_shaping_hash!(shaping)
     end_width = shaping["end_width"]
     if end_width.nil?
       halt 422, {error: "Missing required shaping parameter: end_width"}.to_json
@@ -87,6 +115,29 @@ class PatternEditorApp < Sinatra::Base
     spe = shaping["stitches_per_event"]
     if spe && spe.to_i <= 0
       halt 422, {error: "Shaping parameter must be positive: stitches_per_event"}.to_json
+    end
+  end
+
+  def validate_project_pieces_params!
+    pieces = request_params["pieces"]
+    halt 422, {error: "Missing required parameter: pieces"}.to_json if pieces.nil?
+    halt 422, {error: "Pieces array must not be empty"}.to_json unless pieces.is_a?(Array) && !pieces.empty?
+
+    pieces.each_with_index do |piece, i|
+      label = "pieces[#{i}]"
+      %w[name].each do |key|
+        if piece[key].nil? || (piece[key].is_a?(String) && piece[key].strip.empty?)
+          halt 422, {error: "Missing required parameter in #{label}: #{key}"}.to_json
+        end
+      end
+      %w[width height].each do |key|
+        if piece[key].nil?
+          halt 422, {error: "Missing required parameter in #{label}: #{key}"}.to_json
+        end
+        if piece[key].to_f <= 0
+          halt 422, {error: "Parameter must be positive in #{label}: #{key}"}.to_json
+        end
+      end
     end
   end
 

--- a/apps/pattern-editor/test/api_test.rb
+++ b/apps/pattern-editor/test/api_test.rb
@@ -218,4 +218,166 @@ class PatternEditorApiTest < Minitest::Test
     assert_equal 422, last_response.status
     assert_includes json_response["error"], "stitches_per_event"
   end
+
+  # ----- POST /api/project -----
+
+  def test_post_api_project_returns_all_pieces
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      stitch_pattern: "stockinette",
+      pieces: [
+        {name: "Back", width: 20, height: 25},
+        {name: "Front", width: 20, height: 25, shaping: {end_width: 16}},
+        {name: "Sleeve", width: 10, height: 18, shaping: {end_width: 16}}
+      ]
+    }
+
+    assert last_response.ok?
+    data = json_response
+    assert_equal 3, data["pieces"].length
+
+    back = data["pieces"][0]
+    assert_equal "Back", back["name"]
+    assert_equal 90, back["cast_on"]
+    assert_equal 150, back["total_rows"]
+    refute back["shaping"]["enabled"]
+
+    front = data["pieces"][1]
+    assert_equal "Front", front["name"]
+    assert front["shaping"]["enabled"]
+    assert_equal "decrease", front["shaping"]["method"]
+
+    sleeve = data["pieces"][2]
+    assert_equal "Sleeve", sleeve["name"]
+    assert sleeve["shaping"]["enabled"]
+    assert_equal "increase", sleeve["shaping"]["method"]
+  end
+
+  def test_post_api_project_shared_gauge_applies_to_all
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: [
+        {name: "A", width: 20, height: 25},
+        {name: "B", width: 10, height: 12}
+      ]
+    }
+
+    assert last_response.ok?
+    pieces = json_response["pieces"]
+    assert_equal 90, pieces[0]["cast_on"]
+    assert_equal 150, pieces[0]["total_rows"]
+    assert_equal 45, pieces[1]["cast_on"]
+    assert_equal 72, pieces[1]["total_rows"]
+  end
+
+  def test_post_api_project_with_repeat
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      repeat: {multiple: 4, offset: 2},
+      pieces: [
+        {name: "Panel", width: 20, height: 25}
+      ]
+    }
+
+    assert last_response.ok?
+    assert_equal 2, json_response["pieces"][0]["cast_on"] % 4
+  end
+
+  def test_post_api_project_returns_422_without_pieces
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4}
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "pieces"
+  end
+
+  def test_post_api_project_returns_422_for_empty_pieces
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: []
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "empty"
+  end
+
+  def test_post_api_project_returns_422_for_piece_missing_name
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: [{width: 20, height: 25}]
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "name"
+  end
+
+  def test_post_api_project_returns_422_for_piece_with_empty_name
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: [{name: "  ", width: 20, height: 25}]
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "name"
+  end
+
+  def test_post_api_project_returns_422_for_piece_missing_width
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: [{name: "Back", height: 25}]
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "width"
+  end
+
+  def test_post_api_project_returns_422_for_piece_missing_height
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: [{name: "Back", width: 20}]
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "height"
+  end
+
+  def test_post_api_project_returns_422_for_piece_zero_width
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: [{name: "Back", width: 0, height: 25}]
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "positive"
+  end
+
+  def test_post_api_project_returns_422_without_gauge
+    post_json "/api/project", {
+      pieces: [{name: "Back", width: 20, height: 25}]
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "gauge"
+  end
+
+  def test_post_api_project_validates_per_piece_shaping
+    post_json "/api/project", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      pieces: [{name: "Front", width: 20, height: 25, shaping: {}}]
+    }
+
+    assert_equal 422, last_response.status
+    assert_includes json_response["error"], "end_width"
+  end
+
+  def test_existing_piece_endpoint_still_works
+    post_json "/api/piece", {
+      gauge: {stitches: 18, rows: 24, width: 4},
+      piece: {width: 20, height: 25}
+    }
+
+    assert last_response.ok?
+    assert_equal 90, json_response["cast_on"]
+  end
 end


### PR DESCRIPTION
## Summary

- Add `POST /api/project` endpoint that accepts multiple named pieces with shared gauge, stitch pattern, and repeat (#64)
- Each piece is calculated independently via `PieceService` with optional per-piece shaping
- 13 new API tests covering success paths, validation errors, and backward compatibility

## Test plan

- [x] Multi-piece project returns all calculations (with/without shaping)
- [x] Shared gauge applies to all pieces
- [x] 422 for missing/empty pieces array
- [x] 422 for piece missing required fields (name, width, height)
- [x] 422 for invalid per-piece shaping
- [x] Existing `/api/piece` endpoint unchanged
- [x] All 57 tests pass

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)