### PR TITLE
release(fiber_pattern): v0.6.0

### DIFF
--- a/gems/fiber_pattern/CHANGELOG.md
+++ b/gems/fiber_pattern/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## [0.6.0] - 2026-03-28
+
+### Added
+
+- Add `Piece` value object for deriving physical measurements from gauge
+- Add `Schematic` composer for holding named pieces and dispatching to renderer
+- Add `SvgRenderer` pure-Ruby SVG builder with outlines, labels, and multi-piece layout
+
 ## [0.5.0] - 2026-03-26
 
 ### Added

--- a/gems/fiber_pattern/lib/fiber_pattern/version.rb
+++ b/gems/fiber_pattern/lib/fiber_pattern/version.rb
@@ -3,6 +3,6 @@
 # :nocov:
 module FiberPattern
   # Current gem version.
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end
 # :nocov:


### PR DESCRIPTION
## Summary

Release `fiber_pattern` v0.6.0.

### Changes

- Add `Piece` value object for deriving physical measurements from gauge
- Add `Schematic` composer for holding named pieces and dispatching to renderer
- Add `SvgRenderer` pure-Ruby SVG builder with outlines, labels, and multi-piece layout

## Checklist

- [x] Version bumped in `version.rb`
- [x] Changelog updated with release date
- [x] `[Unreleased]` section is empty
- [x] Tests pass (126 tests, 0 failures)
- [x] Branch follows `release/<gem>-v<version>` convention

> Merging this PR will trigger the release workflow to publish to RubyGems and create a GitHub release.